### PR TITLE
Add public paid support issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Paid service scope and terms
+    url: https://github.com/cacity/VideoHub/blob/main/SERVICES.md
+    about: Review fixed prices, deliverables, acceptance criteria, and payment gates before opening a request.

--- a/.github/ISSUE_TEMPLATE/paid-support.yml
+++ b/.github/ISSUE_TEMPLATE/paid-support.yml
@@ -1,0 +1,91 @@
+name: Paid support request
+description: Request fixed-scope setup, diagnosis, workflow, or team deployment support.
+title: "[Paid support] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for considering paid VideoHub support. This form is public.
+
+        Do not paste passwords, API keys, cookies, private download links, confidential media, personal data, or unpublished customer materials. Use placeholders and a legally shareable, sanitized example only.
+
+        Published options: USD 149 async diagnosis, USD 299 QuickStart, USD 999 Creator Series Workflow, and USD 2,999 Team Local Deployment. Opening this issue is an inquiry, not an order or payment obligation.
+
+  - type: dropdown
+    id: service
+    attributes:
+      label: Service option
+      description: Choose the closest option. Scope is confirmed before payment.
+      options:
+        - USD 149 — Async environment diagnosis
+        - USD 299 — QuickStart remote setup
+        - USD 999 — Creator Series Workflow
+        - USD 2,999 — Team Local Deployment
+        - Not sure — qualification only
+    validations:
+      required: true
+
+  - type: input
+    id: operating-system
+    attributes:
+      label: Operating system and hardware
+      description: "Example: Windows 11, 32 GB RAM, NVIDIA RTX 4060. Do not include device IDs or account details."
+      placeholder: Windows version, RAM, CPU/GPU
+    validations:
+      required: true
+
+  - type: textarea
+    id: workflow-goal
+    attributes:
+      label: Workflow goal
+      description: Describe the input, expected output, volume, and the step currently blocking you.
+      placeholder: We have authorized local MP4 files and need...
+    validations:
+      required: true
+
+  - type: textarea
+    id: sanitized-evidence
+    attributes:
+      label: Sanitized evidence
+      description: Paste only non-sensitive error text or a summary from support_preflight.py. Never include secret values or private file links.
+      placeholder: Error summary or redacted preflight details
+    validations:
+      required: false
+
+  - type: input
+    id: target-date
+    attributes:
+      label: Target date
+      description: Give a realistic date and timezone.
+      placeholder: YYYY-MM-DD, timezone
+    validations:
+      required: true
+
+  - type: dropdown
+    id: buyer-type
+    attributes:
+      label: Buyer type
+      options:
+        - Individual
+        - Team or organization
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: authorization
+    attributes:
+      label: Authorization and scope confirmation
+      options:
+        - label: I have the right to provide and process the described materials.
+          required: true
+        - label: I will not provide passwords, tokens, cookies, restricted data, or confidential media in this public issue.
+          required: true
+        - label: I understand that third-party API, cloud, and media-license costs are not included.
+          required: true
+        - label: I understand that work starts only after written scope confirmation and the required verified payment or funded platform milestone.
+          required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        Maintainer: **stark fng**. A response will confirm whether the request fits a published tier, the exact deliverables, acceptance checks, schedule, and payment gate. Do not send private materials until a secure transfer method is agreed.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ VideoHub 的 MIT 开源版本继续免费。如果你不想自己排查 Python�
 - **Creator Series Workflow — USD 999**：统一系列字幕、画幅、音色、封面和三个授权样例。
 - **Team Local Deployment — USD 2,999**：团队私有部署、一个定制流程、验收、培训和 30 天缺陷支持。
 
-服务不包括绕过平台限制、处理未授权内容、第三方 API 费用或无限期维护。查看[完整服务范围、验收与付款说明](./SERVICES.md)，或向 [stark fng 发送预填咨询邮件](mailto:gf7823332@gmail.com?subject=VideoHub%20paid%20support&body=Service%20tier%3A%0AOperating%20system%3A%0AWorkflow%20goal%3A%0AAuthorized%20sample%3A%0ATarget%20date%3A%0AIndividual%20or%20team%3A)。
+服务不包括绕过平台限制、处理未授权内容、第三方 API 费用或无限期维护。查看[完整服务范围、验收与付款说明](./SERVICES.md)，可直接提交[公开的付费支持申请](https://github.com/cacity/VideoHub/issues/new?template=paid-support.yml)，或向 [stark fng 发送预填咨询邮件](mailto:gf7823332@gmail.com?subject=VideoHub%20paid%20support&body=Service%20tier%3A%0AOperating%20system%3A%0AWorkflow%20goal%3A%0AAuthorized%20sample%3A%0ATarget%20date%3A%0AIndividual%20or%20team%3A)。公开 Issue 中禁止粘贴密钥、私有素材或个人敏感信息。
 
 先看证据：[11 期授权艺术内容系列的匿名案例](./CASE_STUDY.md)，包含可在仓库中复核的成片、字幕、章节、发布说明和 44 张多画幅封面；不把内部产出数量包装成客户数量或商业收益。
 

--- a/README_en.md
+++ b/README_en.md
@@ -15,7 +15,7 @@ The MIT-licensed open-source edition remains free. Fixed-scope implementation se
 - **Creator Series Workflow — USD 999**: consistent subtitles, aspect ratio, voice, covers, and three authorized samples.
 - **Team Local Deployment — USD 2,999**: private deployment, one custom workflow, acceptance testing, training, and 30 days of defect support.
 
-Services do not include bypassing platform restrictions, processing unlicensed content, third-party API costs, or unlimited maintenance. Read the [full scope, acceptance, and payment terms](./SERVICES.md), or [start a prefilled inquiry with stark fng](mailto:gf7823332@gmail.com?subject=VideoHub%20paid%20support&body=Service%20tier%3A%0AOperating%20system%3A%0AWorkflow%20goal%3A%0AAuthorized%20sample%3A%0ATarget%20date%3A%0AIndividual%20or%20team%3A).
+Services do not include bypassing platform restrictions, processing unlicensed content, third-party API costs, or unlimited maintenance. Read the [full scope, acceptance, and payment terms](./SERVICES.md), open a [public paid support request](https://github.com/cacity/VideoHub/issues/new?template=paid-support.yml), or [start a prefilled inquiry with stark fng](mailto:gf7823332@gmail.com?subject=VideoHub%20paid%20support&body=Service%20tier%3A%0AOperating%20system%3A%0AWorkflow%20goal%3A%0AAuthorized%20sample%3A%0ATarget%20date%3A%0AIndividual%20or%20team%3A). Never post secrets, private media, or personal data in a public issue.
 
 Review the evidence first: the [anonymized 11-episode authorized art-content case study](./CASE_STUDY.md) links the claim to repository-verifiable videos, subtitles, chapters, release notes, and 44 multi-format covers. Internal output counts are not presented as client counts or business results.
 

--- a/SERVICES.md
+++ b/SERVICES.md
@@ -4,7 +4,9 @@ VideoHub 的 MIT 开源版本继续免费。以下费用购买的是固定范围
 
 联系 / Contact: **stark fng** · [gf7823332@gmail.com](mailto:gf7823332@gmail.com?subject=VideoHub%20paid%20support)
 
-[发送预填咨询邮件 / Start an inquiry](mailto:gf7823332@gmail.com?subject=VideoHub%20paid%20support&body=Service%20tier%3A%0AOperating%20system%3A%0AWorkflow%20goal%3A%0AAuthorized%20sample%3A%0ATarget%20date%3A%0AIndividual%20or%20team%3A)
+[提交公开付费支持申请 / Open a public paid support request](https://github.com/cacity/VideoHub/issues/new?template=paid-support.yml) · [发送预填咨询邮件 / Start an inquiry](mailto:gf7823332@gmail.com?subject=VideoHub%20paid%20support&body=Service%20tier%3A%0AOperating%20system%3A%0AWorkflow%20goal%3A%0AAuthorized%20sample%3A%0ATarget%20date%3A%0AIndividual%20or%20team%3A)
+
+公开 Issue 中禁止粘贴密码、API 密钥、cookies、私有下载链接、保密素材或个人敏感信息。Never post passwords, API keys, cookies, private links, confidential media, or personal data in a public issue.
 
 ## 服务对比
 


### PR DESCRIPTION
## What changed

- add a structured public paid-support Issue form for USD 149 / 299 / 999 / 2,999 services
- require authorization and scope confirmations
- warn users not to post secrets, private media, links, or personal data
- link the form from the Chinese and English READMEs and `SERVICES.md`

## Why

This provides an inbound path that does not require outbound email. It keeps qualification public and structured while preserving clear privacy and payment gates.

## Validation

- parsed both YAML files with PyYAML (`YAML_OK 2`)
- verified 9 form body blocks
- `git diff --check` passes
- no website files changed
- no existing Issue was modified or replied to
